### PR TITLE
TECH: Add types definitions and change export to node exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+import { Logger } from 'winston';
+import { Handler } from 'express';
+
+declare namespace strigoNodeLogger {
+  function setupNodeLogger(env: string, level?: string): Logger;
+  function setupExpressLogger(env: string, level?: string): { logger: Logger, loggerMiddleware: Handler };
+}
+
+export = strigoNodeLogger;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function configureFormatters(env) {
  * @param {String} env The name of the environment to use. This affects formatting.
  * @param {String} level The level to use when setting the logger up.
  */
-export function setupNodeLogger(env, level = DEFAULT_LOG_LEVEL) {
+function setupNodeLogger(env, level = DEFAULT_LOG_LEVEL) {
   return createLogger({
     level,
     format: format.combine(...configureFormatters(env)),
@@ -59,7 +59,7 @@ export function setupNodeLogger(env, level = DEFAULT_LOG_LEVEL) {
  * @param {String} env The name of the environment to use. This affects formatting.
  * @param {String} level The level to use when setting the logger up.
  */
-export function setupExpressLogger(env, level = DEFAULT_LOG_LEVEL) {
+function setupExpressLogger(env, level = DEFAULT_LOG_LEVEL) {
   const logger = setupNodeLogger(env, level);
 
   const loggerMiddleware = expressWinston.logger({
@@ -71,4 +71,9 @@ export function setupExpressLogger(env, level = DEFAULT_LOG_LEVEL) {
   });
 
   return { logger, loggerMiddleware };
+}
+
+module.exports = {
+  setupNodeLogger,
+  setupExpressLogger
 }


### PR DESCRIPTION
1. Add types definition for the logger to be available in typescript projects.
2. Change export to default node exports to avoid transpiling in the destination projects.