### PR TITLE
Allow express to add custom context to logs meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ For Express.js specifically, make sure to [read this](https://github.com/bithavo
 
 ## Installation
 
-Add `"strigo-node-logger": "strigo/strigo-node-logger.git#TAG"` to your `package.json`.
+Add `"@strigo/node-logger": "strigo/strigo-node-logger.git#TAG"` to your `package.json`.
 
 ## Usage
 
 ### In a vanilla node application
 
 ```javascript
-import { setupNodeLogger } from 'strigo-node-logger';
+import { setupNodeLogger } from '@strigo/node-logger';
 
 const log = setupNodeLogger({ json = true, level = 'info' });
 
@@ -34,7 +34,7 @@ log.debug(...);
 ### In an ExpressJS application
 
 ```javascript
-import { setupExpressLogger } from 'strigo-node-logger';
+import { setupExpressLogger } from '@strigo/node-logger';
 
 const { log, loggerMiddleware, errorLoggerMiddleware } = setupExpressLogger({});
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "express-winston": "4.0.3",
     "fast-safe-stringify": "2.0.7",
+    "lodash.isplainobject": "4.0.6",
     "logform": "2.1.2",
     "triple-beam": "1.3.0",
     "winston": "3.2.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "strigo-node-logger",
+  "name": "@strigo/node-logger",
   "version": "0.0.0",
   "description": "A strigo abstraction for a logger utility",
   "main": "index.js",


### PR DESCRIPTION
Extend the express log middleware to add custom context from the request to logs' meta.
This is useful in cases when we need to add userId, organizationId, etc. to all express logs seamlessly.