### PR TITLE
Allow to override logger instance for express middleware

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
 import { Logger } from 'winston';
 import { Handler } from 'express';
-import { RouteFilter } from 'express-winston';
-
 declare namespace strigoNodeLogger {
   type NodeLoggerOptions = {
     json?: boolean;
@@ -15,7 +13,8 @@ declare namespace strigoNodeLogger {
   }
 
   type NodeExpressLoggerOptions = NodeLoggerOptions & {
-    skip?: SkipOptions[]
+    skip?: SkipOptions[],
+    logger?: Logger
   }
 
   function setupNodeLogger(loggerOptions: NodeLoggerOptions): Logger;

--- a/setup/express.js
+++ b/setup/express.js
@@ -16,11 +16,13 @@ const defaultMatchers = [
  * @param {String} level The level to use when setting the logger up.
  * @param {Array} skip Custom log filter
  */
-function setupExpressLogger({ json = true, level = DEFAULT_LOG_LEVEL, skip = defaultMatchers }) {
-  const logger = setupNodeLogger({ json, level });
+function setupExpressLogger({
+  json = true, level = DEFAULT_LOG_LEVEL, skip = defaultMatchers, logger,
+}) {
+  const activeLogger = logger || setupNodeLogger({ json, level });
 
   const loggerMiddleware = expressWinston.logger({
-    winstonInstance: logger,
+    winstonInstance: activeLogger,
     metaField: null,
     requestField: null,
     responseField: null,
@@ -32,7 +34,7 @@ function setupExpressLogger({ json = true, level = DEFAULT_LOG_LEVEL, skip = def
   });
 
   const errorLoggerMiddleware = expressWinston.errorLogger({
-    winstonInstance: logger,
+    winstonInstance: activeLogger,
     msg: (req) => `ERROR ${req.method} ${req.originalUrl}`,
     metaField: null,
     blacklistedMetaFields: ['trace', 'date', 'os', 'uptime', 'process', 'exception', 'stack'],
@@ -40,7 +42,7 @@ function setupExpressLogger({ json = true, level = DEFAULT_LOG_LEVEL, skip = def
     dynamicMeta: ecsMeta,
   });
 
-  return { logger, loggerMiddleware, errorLoggerMiddleware };
+  return { logger: activeLogger, loggerMiddleware, errorLoggerMiddleware };
 }
 
 module.exports = {


### PR DESCRIPTION
For async context implementation we'll need the option to customize clogger for express middleware